### PR TITLE
Removed valloc 

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -2219,7 +2219,7 @@ _dispatch_operation_perform(dispatch_operation_t op)
 			} else {
 				op->buf_siz = max_buf_siz;
 			}
-			op->buf = valloc(op->buf_siz);
+			op->buf = memalign(sysconf(_SC_PAGESIZE), op->buf_siz);
 			_dispatch_op_debug("buffer allocated", op);
 		} else if (op->direction == DOP_DIR_WRITE) {
 			// Always write the first data piece, if that is smaller than a

--- a/src/io.c
+++ b/src/io.c
@@ -2219,7 +2219,7 @@ _dispatch_operation_perform(dispatch_operation_t op)
 			} else {
 				op->buf_siz = max_buf_siz;
 			}
-			op->buf = memalign(sysconf(_SC_PAGESIZE), op->buf_siz);
+			posix_memalign(op->buf, (size_t)sysconf(_SC_PAGESIZE), op->buf_siz);
 			_dispatch_op_debug("buffer allocated", op);
 		} else if (op->direction == DOP_DIR_WRITE) {
 			// Always write the first data piece, if that is smaller than a

--- a/tests/dispatch_io.c
+++ b/tests/dispatch_io.c
@@ -370,7 +370,7 @@ test_async_read(char *path, size_t size, int option, dispatch_queue_t queue,
 		case DISPATCH_ASYNC_READ_ON_CONCURRENT_QUEUE:
 		case DISPATCH_ASYNC_READ_ON_SERIAL_QUEUE:
 			dispatch_async(queue, ^{
-				char* buffer = valloc(size);
+				char *buffer = memalign(sysconf(_SC_PAGESIZE), size);
 				ssize_t r = read(fd, buffer, size);
 				if (r == -1) {
 					test_errno("async read error", errno, 0);

--- a/tests/dispatch_io.c
+++ b/tests/dispatch_io.c
@@ -370,7 +370,8 @@ test_async_read(char *path, size_t size, int option, dispatch_queue_t queue,
 		case DISPATCH_ASYNC_READ_ON_CONCURRENT_QUEUE:
 		case DISPATCH_ASYNC_READ_ON_SERIAL_QUEUE:
 			dispatch_async(queue, ^{
-				char *buffer = memalign(sysconf(_SC_PAGESIZE), size);
+				char *buffer;
+				posix_memalign(buffer, (size_t)sysconf(_SC_PAGESIZE), size);
 				ssize_t r = read(fd, buffer, size);
 				if (r == -1) {
 					test_errno("async read error", errno, 0);

--- a/tests/dispatch_read2.c
+++ b/tests/dispatch_read2.c
@@ -79,7 +79,8 @@ dispatch_read2(dispatch_fd_t fd,
 	__block int err = 0;
 	dispatch_source_set_event_handler(reader, ^{
 		const ssize_t bufsiz = 1024*512; // 512KB buffer
-		char *buffer = memalign(sysconf(_SC_PAGESIZE), bufsiz);
+		char *buffer;
+        posix_memalign(buffer, (size_t)sysconf(_SC_PAGESIZE), bufsiz);
 		ssize_t actual = read(fd, buffer, bufsiz);
 		if (actual == -1) {
 			err = errno;

--- a/tests/dispatch_read2.c
+++ b/tests/dispatch_read2.c
@@ -79,7 +79,7 @@ dispatch_read2(dispatch_fd_t fd,
 	__block int err = 0;
 	dispatch_source_set_event_handler(reader, ^{
 		const ssize_t bufsiz = 1024*512; // 512KB buffer
-		char *buffer = valloc(bufsiz);
+		char *buffer = memalign(sysconf(_SC_PAGESIZE), bufsiz);
 		ssize_t actual = read(fd, buffer, bufsiz);
 		if (actual == -1) {
 			err = errno;

--- a/tests/dispatch_vm.c
+++ b/tests/dispatch_vm.c
@@ -155,7 +155,7 @@ main(void)
 			dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 		while (handler_call_count < NOTIFICATIONS &&
 				page_count < max_page_count) {
-			void *p = valloc(ALLOC_SIZE);
+			void *p = memalign(sysconf(_SC_PAGESIZE), ALLOC_SIZE);
 			if (!p) {
 				break;
 			}

--- a/tests/dispatch_vm.c
+++ b/tests/dispatch_vm.c
@@ -155,7 +155,8 @@ main(void)
 			dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 		while (handler_call_count < NOTIFICATIONS &&
 				page_count < max_page_count) {
-			void *p = memalign(sysconf(_SC_PAGESIZE), ALLOC_SIZE);
+			void *p;
+			posix_memalign(p, (size_t)sysconf(_SC_PAGESIZE), ALLOC_SIZE);
 			if (!p) {
 				break;
 			}


### PR DESCRIPTION
`valloc()` seems to be no longer available on android devices with arm64. Removed it and use `posix_memalign()` instead.